### PR TITLE
Updates - Bullseye & default lib versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@
 # (Forked from: https://github.com/krull/docker-janus)
 ############################################################
 
-# set base image debian jessie
-FROM debian:buster
+# set base image debian bullseye
+FROM debian:bullseye
 
 # file maintainer author
 LABEL maintainer="kmeyerhofer <k@kcmr.io>"
@@ -109,7 +109,7 @@ RUN set -x && \
     tar xzf ./${LIBNICE_VERSION}.tar.gz -C . && \
     cd ./libnice-${LIBNICE_VERSION} && \
     if [ "${LIBNICE_VERSION}" > "0.1.17" ]; then meson builddir && \
-      sudo ninja -C builddir install; \
+      ninja -C builddir install; \
     else ./autogen.sh && \
       ./configure --prefix=/usr && \
       make && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
 ############################################################
-# Dockerfile - Janus Gateway on Debian Buster
-# https://github.com/kmeyerhofer/docker-janus
+# Dockerfile - Janus Gateway on Debian Bullseye
+# https://github.com/Ambiki/docker-janus
 # (Forked from: https://github.com/krull/docker-janus)
 ############################################################
 
 # set base image debian bullseye
 FROM debian:bullseye
-
-# file maintainer author
-LABEL maintainer="kmeyerhofer <k@kcmr.io>"
 
 # library versions
 ARG   JANUS_VERSION=0.11.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM debian:bullseye
 
 # library versions
 ARG   JANUS_VERSION=0.11.8
-ARG LIBSRTP_VERSION=2.2.0
+ARG LIBSRTP_VERSION=2.4.2
 ARG LIBNICE_VERSION=0.1.18
 
 # docker build arguments

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL maintainer="kmeyerhofer <k@kcmr.io>"
 # library versions
 ARG   JANUS_VERSION=0.10.7
 ARG LIBSRTP_VERSION=2.2.0
-ARG LIBNICE_VERSION=0.1.17
+ARG LIBNICE_VERSION=0.1.18
 
 # docker build arguments
 ARG JANUS_WITH_POSTPROCESSING="1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM debian:bullseye
 LABEL maintainer="kmeyerhofer <k@kcmr.io>"
 
 # library versions
-ARG   JANUS_VERSION=0.10.7
+ARG   JANUS_VERSION=0.11.8
 ARG LIBSRTP_VERSION=2.2.0
 ARG LIBNICE_VERSION=0.1.18
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,8 +109,8 @@ RUN set -x && \
     tar xzf ./${LIBNICE_VERSION}.tar.gz -C . && \
     cd ./libnice-${LIBNICE_VERSION} && \
     if [ "${LIBNICE_VERSION}" > "0.1.17" ]; then meson builddir && \
-      sudo ninja -C builddir install && \
-    ; else ./autogen.sh && \
+      sudo ninja -C builddir install; \
+    else ./autogen.sh && \
       ./configure --prefix=/usr && \
       make && \
       make install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG JANUS_BUILD_DEPS_DEV="\
     libconfig-dev \
     gtk-doc-tools \
     meson \
-    ninja-build
+    ninja-build \
     "
 #    libnice-dev \ # Version 0.1.14 - outdated
 ARG JANUS_BUILD_DEPS_EXT="\

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,8 @@ ARG JANUS_BUILD_DEPS_DEV="\
     pkg-config \
     libconfig-dev \
     gtk-doc-tools \
+    meson \
+    ninja-build
     "
 #    libnice-dev \ # Version 0.1.14 - outdated
 ARG JANUS_BUILD_DEPS_EXT="\
@@ -106,10 +108,13 @@ RUN set -x && \
     curl -fSL https://github.com/libnice/libnice/archive/${LIBNICE_VERSION}.tar.gz -o ./${LIBNICE_VERSION}.tar.gz && \
     tar xzf ./${LIBNICE_VERSION}.tar.gz -C . && \
     cd ./libnice-${LIBNICE_VERSION} && \
-    ./autogen.sh && \
-    ./configure --prefix=/usr && \
-    make && \
-    make install
+    if [ ${LIBNICE_VERSION} > "0.1.17" ]; then meson builddir && \
+      sudo ninja -C builddir install && \
+    elif [ ${LIBNICE_VERSION} < "0.1.18" ]; then ./autogen.sh && \
+      ./configure --prefix=/usr && \
+      make && \
+      make install \
+    ; fi
 
 # build boringssl
 RUN set -x && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,9 +108,9 @@ RUN set -x && \
     curl -fSL https://github.com/libnice/libnice/archive/${LIBNICE_VERSION}.tar.gz -o ./${LIBNICE_VERSION}.tar.gz && \
     tar xzf ./${LIBNICE_VERSION}.tar.gz -C . && \
     cd ./libnice-${LIBNICE_VERSION} && \
-    if [ ${LIBNICE_VERSION} > "0.1.17" ]; then meson builddir && \
+    if [ "${LIBNICE_VERSION}" > "0.1.17" ]; then meson builddir && \
       sudo ninja -C builddir install && \
-    elif [ ${LIBNICE_VERSION} < "0.1.18" ]; then ./autogen.sh && \
+    ; else ./autogen.sh && \
       ./configure --prefix=/usr && \
       make && \
       make install \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # docker-janus
-`docker-janus` is a Debian 10 (buster) based docker image for [Meetecho's Janus Gateway](https://github.com/meetecho/janus-gateway)
+`docker-janus` is a Debian 11 (bullseye) based docker image for [Meetecho's Janus Gateway](https://github.com/meetecho/janus-gateway)
 
 ## Description
 All the janus docker builds I have seen in hub.docker.com were all ubuntu based and/or of some redhat flavor. I successfully build janus in debian 7 and 8 before, so I thought it would be a good way to practice docker best practices and provide a debian based image at the same time.


### PR DESCRIPTION
Requires a build of meson:

`meson.build:1:0: ERROR:  Meson version is 0.49.2 but project requires >= 0.52.`


# Updates
Updates to Debian Bullseye (11).
Updates default:
- JANUS_VERSION to 0.11.8
- LIBSRTP_VERSION to 2.4.2
- LIBNICE_VERSION to 0.1.18